### PR TITLE
add impersonation to user, and metadata to user and org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propelauth"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["support@propelauth.com"]
 description = "A Rust crate for managing authentication and authorization with support for multi-tenant / B2B products, powered by PropelAuth"
 keywords = ["authentication", "auth", "authorization", "b2b", "tenant"]
@@ -10,18 +10,16 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
+actix-web = { version = "4", optional = true }
+axum = { version = "^0.6", optional = true }
+jsonwebtoken = "8.1.1"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
 thiserror = "^1.0"
+tower = { version = "^0.4", optional = true }
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde"] }
-jsonwebtoken = "8.1.1"
-
-axum = { version = "^0.6", optional = true }
-tower = { version = "^0.4", optional = true }
-
-actix-web = { version = "4", optional = true }
 
 [dependencies.reqwest]
 version = "^0.11"

--- a/src/models/update_metadata_request.rs
+++ b/src/models/update_metadata_request.rs
@@ -11,6 +11,10 @@
 
 
 
+use std::collections::HashMap;
+
+use serde_json::Value;
+
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct UpdateMetadataRequest {
     #[serde(rename = "username", skip_serializing_if = "Option::is_none")]
@@ -21,6 +25,8 @@ pub struct UpdateMetadataRequest {
     pub last_name: Option<String>,
     #[serde(rename = "picture_url", skip_serializing_if = "Option::is_none")]
     pub picture_url: Option<String>,
+    #[serde(rename = "metadata", skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
 }
 
 impl UpdateMetadataRequest {
@@ -30,6 +36,7 @@ impl UpdateMetadataRequest {
             first_name: None,
             last_name: None,
             picture_url: None,
+            metadata: None,
         }
     }
 }

--- a/src/models/update_org_request.rs
+++ b/src/models/update_org_request.rs
@@ -11,12 +11,18 @@
 
 
 
+use std::collections::HashMap;
+
+use serde_json::Value;
+
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct UpdateOrgRequest {
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(rename = "can_setup_saml", skip_serializing_if = "Option::is_none")]
     pub can_setup_saml: Option<bool>,
+    #[serde(rename = "metadata", skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
 }
 
 impl UpdateOrgRequest {
@@ -24,6 +30,7 @@ impl UpdateOrgRequest {
         UpdateOrgRequest {
             name: None,
             can_setup_saml: None,
+            metadata: None,
         }
     }
 }

--- a/src/models/user_metadata.rs
+++ b/src/models/user_metadata.rs
@@ -11,6 +11,10 @@
 
 
 
+use std::collections::HashMap;
+
+use serde_json::Value;
+
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct UserMetadata {
     #[serde(rename = "user_id")]
@@ -40,9 +44,13 @@ pub struct UserMetadata {
     #[serde(rename = "last_active_at")]
     pub last_active_at: i64,
     #[serde(rename = "org_id_to_org_info", skip_serializing_if = "Option::is_none")]
-    pub org_id_to_org_info: Option<::std::collections::HashMap<String, crate::models::UserInOrg>>,
+    pub org_id_to_org_info: Option<HashMap<String, crate::models::UserInOrg>>,
     #[serde(rename = "legacy_user_id", skip_serializing_if = "Option::is_none")]
     pub legacy_user_id: Option<String>,
+    #[serde(rename = "impersonated_user_id", skip_serializing_if = "Option::is_none")]
+    pub impersonated_user_id: Option<String>,
+    #[serde(rename = "metadata", skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
 }
 
 impl UserMetadata {
@@ -63,6 +71,8 @@ impl UserMetadata {
             last_active_at,
             org_id_to_org_info: None,
             legacy_user_id: None,
+            impersonated_user_id: None,
+            metadata: None,
         }
     }
 }

--- a/src/propelauth/token.rs
+++ b/src/propelauth/token.rs
@@ -1,10 +1,11 @@
+use jsonwebtoken::{Algorithm, decode, DecodingKey, Validation};
+
 use crate::models::AuthTokenVerificationMetadata;
 use crate::propelauth::errors::{
     DetailedAuthError, UnauthorizedError, UnauthorizedOrForbiddenError,
 };
 use crate::propelauth::options::{RequiredOrg, UserRequirementsInOrg};
 use crate::propelauth::token_models::{User, UserAndOrgMemberInfo};
-use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 
 pub struct TokenService<'a> {
     pub(crate) token_verification_metadata: &'a AuthTokenVerificationMetadata,
@@ -64,6 +65,12 @@ impl TokenService<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::time::SystemTime;
+
+    use jsonwebtoken::{Algorithm, encode, EncodingKey, Header};
+    use openssl::rsa::Rsa;
+
     use crate::models::AuthTokenVerificationMetadata;
     use crate::propelauth::errors::{
         DetailedAuthError, DetailedForbiddenError, UnauthorizedError, UnauthorizedOrForbiddenError,
@@ -72,10 +79,6 @@ mod tests {
     use crate::propelauth::options::UserRequirementsInOrg;
     use crate::propelauth::token::TokenService;
     use crate::propelauth::token_models::{OrgMemberInfo, User, UserAndOrgMemberInfo};
-    use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
-    use openssl::rsa::Rsa;
-    use std::collections::HashMap;
-    use std::time::SystemTime;
 
     const ISSUER: &'static str = "https://testissuer.propelauthtest.com";
 
@@ -108,6 +111,8 @@ mod tests {
             user_id: "bf7b3bc0-739d-45a2-ba60-60655249a5b0".to_string(),
             org_id_to_org_member_info: get_org_id_to_org_member_info(),
             legacy_user_id: Some("legacy_id".to_string()),
+            impersonated_user_id: None,
+            metadata: HashMap::new(),
         };
         let (jwt, token_verification_metadata) =
             get_jwt_and_token_verification_metadata(expected_user.clone(), 24);
@@ -209,6 +214,8 @@ mod tests {
             user_id: "bf7b3bc0-739d-45a2-ba60-60655249a5b0".to_string(),
             org_id_to_org_member_info: get_org_id_to_org_member_info(),
             legacy_user_id: Some("legacy_id".to_string()),
+            impersonated_user_id: None,
+            metadata: HashMap::new(),
         };
         let (jwt, token_verification_metadata) =
             get_jwt_and_token_verification_metadata(expected_user.clone(), 24);
@@ -364,6 +371,8 @@ mod tests {
             user_id: "bf7b3bc0-739d-45a2-ba60-60655249a5b0".to_string(),
             org_id_to_org_member_info: get_org_id_to_org_member_info(),
             legacy_user_id: Some("legacy_id".to_string()),
+            impersonated_user_id: None,
+            metadata: HashMap::new(),
         };
         let (jwt, token_verification_metadata) =
             get_jwt_and_token_verification_metadata(expected_user.clone(), 24);
@@ -443,6 +452,7 @@ mod tests {
             OrgMemberInfo {
                 org_id: "org_id_1".to_string(),
                 org_name: "org_name_1".to_string(),
+                org_metadata: HashMap::new(),
                 url_safe_org_name: "org_name_1".to_string(),
                 user_role: "Owner".to_string(),
                 inherited_user_roles_plus_current_role: vec![
@@ -458,6 +468,7 @@ mod tests {
             OrgMemberInfo {
                 org_id: "org_id_2".to_string(),
                 org_name: "org_name_2".to_string(),
+                org_metadata: HashMap::new(),
                 url_safe_org_name: "org_name_2".to_string(),
                 user_role: "Admin".to_string(),
                 inherited_user_roles_plus_current_role: vec![
@@ -472,6 +483,7 @@ mod tests {
             OrgMemberInfo {
                 org_id: "org_id_3".to_string(),
                 org_name: "org_name_3".to_string(),
+                org_metadata: HashMap::new(),
                 url_safe_org_name: "org_name_3".to_string(),
                 user_role: "Member".to_string(),
                 inherited_user_roles_plus_current_role: vec!["Member".to_string()],

--- a/src/propelauth/token_models.rs
+++ b/src/propelauth/token_models.rs
@@ -1,8 +1,11 @@
-use crate::propelauth::errors::DetailedForbiddenError;
-use crate::propelauth::options::{RequiredOrg, UserRequirementsInOrg};
-use serde::{Deserialize, Serialize};
 use std::collections::hash_map::{Keys, Values};
 use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::propelauth::errors::DetailedForbiddenError;
+use crate::propelauth::options::{RequiredOrg, UserRequirementsInOrg};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct User {
@@ -15,6 +18,13 @@ pub struct User {
      *  this is their original ID from that system. */
     #[serde(default)]
     pub legacy_user_id: Option<String>,
+
+    #[serde(default)]
+    pub impersonated_user_id: Option<String>,
+
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+
 }
 
 impl User {
@@ -85,12 +95,17 @@ impl User {
     pub fn get_num_orgs(&self) -> usize {
         self.org_id_to_org_member_info.len()
     }
+
+    pub fn is_impersonated(&self) -> bool {
+        self.impersonated_user_id.is_some()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct OrgMemberInfo {
     pub org_id: String,
     pub org_name: String,
+    pub org_metadata: HashMap<String, Value>,
     pub url_safe_org_name: String,
     pub user_role: String,
     pub inherited_user_roles_plus_current_role: Vec<String>,


### PR DESCRIPTION
The User now has an "impersonator_user_id" field. This is the UUID of the other user that is impersonating this user. It will be None if impersonation is not happening (which it normally isn't).

The User objects also have a "metadata" field, which is private, user-specific metadata which can be set via the regular update_metadata endpoint. The user will never see or use this metadata, it's just for the PropelAuth customer.

The Org objects have an "org_metadata" field. Much like user metadata, this is a private field.

The metadata objects are simple hashes with a string key and any JSON object for the value.