### PR TITLE
Fix typo in Axum documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! let app = Router::new()
 //!     .route("/whoami", get(whoami))
 //!     .route("/org/:org_name/whoami", get(org_whoami))
-//!     .layer(layer); // <-- here
+//!     .layer(auth_layer); // <-- here
 //! ```
 //!
 //! You can then take `User` in as an argument, which will look for an [access token](https://docs.propelauth.com/overview/access-token/) in the Authorization header.


### PR DESCRIPTION
The layer name is `auth_layer`, not `layer`.