### PR TITLE
[HOTFIX] Remove impersonation from `UserMetadata` and fix typo on `User`

### DIFF
--- a/src/models/user_metadata.rs
+++ b/src/models/user_metadata.rs
@@ -47,8 +47,6 @@ pub struct UserMetadata {
     pub org_id_to_org_info: Option<HashMap<String, crate::models::UserInOrg>>,
     #[serde(rename = "legacy_user_id", skip_serializing_if = "Option::is_none")]
     pub legacy_user_id: Option<String>,
-    #[serde(rename = "impersonated_user_id", skip_serializing_if = "Option::is_none")]
-    pub impersonated_user_id: Option<String>,
     #[serde(rename = "metadata", skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, Value>>,
     #[serde(rename = "properties", skip_serializing_if = "Option::is_none")]
@@ -73,7 +71,6 @@ impl UserMetadata {
             last_active_at,
             org_id_to_org_info: None,
             legacy_user_id: None,
-            impersonated_user_id: None,
             metadata: None,
             properties: None,
         }

--- a/src/propelauth/token.rs
+++ b/src/propelauth/token.rs
@@ -115,7 +115,7 @@ mod tests {
             username: None,
             org_id_to_org_member_info: get_org_id_to_org_member_info(),
             legacy_user_id: Some("legacy_id".to_string()),
-            impersonated_user_id: None,
+            impersonator_user_id: None,
             metadata: HashMap::new(),
         };
         let (jwt, token_verification_metadata) =
@@ -226,7 +226,7 @@ mod tests {
             username: None,
             org_id_to_org_member_info: get_org_id_to_org_member_info(),
             legacy_user_id: Some("legacy_id".to_string()),
-            impersonated_user_id: None,
+            impersonator_user_id: None,
             metadata: HashMap::new(),
         };
         let (jwt, token_verification_metadata) =
@@ -387,7 +387,7 @@ mod tests {
             username: None,
             org_id_to_org_member_info: get_org_id_to_org_member_info(),
             legacy_user_id: Some("legacy_id".to_string()),
-            impersonated_user_id: None,
+            impersonator_user_id: None,
             metadata: HashMap::new(),
         };
         let (jwt, token_verification_metadata) =

--- a/src/propelauth/token_models.rs
+++ b/src/propelauth/token_models.rs
@@ -28,7 +28,7 @@ pub struct User {
     pub legacy_user_id: Option<String>,
 
     #[serde(default)]
-    pub impersonated_user_id: Option<String>,
+    pub impersonator_user_id: Option<String>,
 
     #[serde(default)]
     pub metadata: HashMap<String, String>,
@@ -105,7 +105,7 @@ impl User {
     }
 
     pub fn is_impersonated(&self) -> bool {
-        self.impersonated_user_id.is_some()
+        self.impersonator_user_id.is_some()
     }
 }
 


### PR DESCRIPTION
The `UserMetadata` struct had a now deprecated field, `impersonated_user_id`; this has been removed. 

As well as this, there was a typo on the `User` struct -- `impersonated_user_id` has been changed to `impersonator_user_id`. 