### PR TITLE
Allow rustls for TLS instead of OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ rustls = ["__reqwest", "reqwest/rustls-tls", "reqwest/http2", "reqwest/charset"]
 axum06 = ["dep:axum_06", "dep:tower"]
 axum07 = ["dep:axum_07", "dep:tower"]
 actix4 = ["dep:actix-web"]
-__reqwest = ["reqwest/json"]
+__reqwest = ["reqwest/json", "reqwest/multipart"]
 
 [lib]
 doctest = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,19 @@ uuid = { version = "^1.0", features = ["serde"] }
 hex = "0.4.3"
 
 [dependencies.reqwest]
-version = "^0.11"
-features = ["json", "multipart"]
+version = "^0.12"
+default-features = false
 
 [dev-dependencies]
 openssl = "0.10.43"
 
 [features]
+default = ["reqwest/default", "__reqwest"]
+rustls = ["__reqwest", "reqwest/rustls-tls", "reqwest/http2", "reqwest/charset"]
 axum06 = ["dep:axum_06", "dep:tower"]
 axum07 = ["dep:axum_07", "dep:tower"]
 actix4 = ["dep:actix-web"]
+__reqwest = ["reqwest/json"]
 
 [lib]
 doctest = false

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ async fn make_req(auth: web::Data<PropelAuth>) -> impl Responder {
 If you'd rather use a pure Rust TLS implementation rather than OpenSSL disable the default features and enable rustls as so:
 
 ```toml
-propelauth = { version = "0.10.1", features = ["axum07", "rustls"], default-features = false }
+propelauth = { version >= "0.12.1", features = ["rustls"], default-features = false }
 ```
 
 ## Other

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ async fn make_req(auth: web::Data<PropelAuth>) -> impl Responder {
 }
 ```
 
+## Rustls instead of OpenSSL
+
+If you'd rather use a pure Rust TLS implementation rather than OpenSSL disable the default features and enable rustls as so:
+
+```toml
+propelauth = { version = "0.10.1", features = ["axum07", "rustls"], default-features = false }
+```
+
 ## Other
 
 After initializing `auth`, you can verify [access tokens](https://docs.propelauth.com/overview/access-token/) by passing in the Authorization header (formatted `Bearer TOKEN`):


### PR DESCRIPTION
* Update Reqwest version
* Update Cargo.toml to allow using Reqwest rustls instead of OpenSSL
* Update the README to explain how to use rustls