### PR TITLE
expires_at_seconds should be Optional

### DIFF
--- a/src/models/fetch_api_key_response.rs
+++ b/src/models/fetch_api_key_response.rs
@@ -2,14 +2,14 @@
 pub struct FetchApiKeyResponse {
     pub api_key_id: String,
     pub created_at: i32,
-    pub expires_at_seconds: i64,
+    pub expires_at_seconds: Option<i64>,
     pub metadata: Option<serde_json::Value>,
     pub user_id: Option<String>,
     pub org_id: Option<String>,
 }
 
 impl FetchApiKeyResponse {
-    pub fn new(api_key_id: String, created_at: i32, expires_at_seconds: i64, metadata: Option<serde_json::Value>, user_id: Option<String>, org_id: Option<String>) -> Self {
+    pub fn new(api_key_id: String, created_at: i32, expires_at_seconds: Option<i64>, metadata: Option<serde_json::Value>, user_id: Option<String>, org_id: Option<String>) -> Self {
         Self { api_key_id, created_at, expires_at_seconds, metadata, user_id, org_id }
     }
 }


### PR DESCRIPTION
I noticed today that in the rust library the fetch active keys function stopped working.
It seems to get a JSON error on return.  When I debug it, the error in memory shows that there was an invalid type: null

When using fetch_current_api_keys()
```
auth
    .api_key()
    .fetch_current_api_keys(ApiKeyQueryParams {
        user_id: None,
        user_email: None,
        org_id: Some(org_id),
        page_size: Some(10),
        page_number: Some(0),
    })
```

When debugging, I find expires_at_seconds set to none (never expires) on some keys, as expected.
But expires_at_seconds is not optional, causing the issue (from this struct):
```
#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
pub struct FetchApiKeyResponse {
    pub api_key_id: String,
    pub created_at: i32,
    pub expires_at_seconds: i64,
    pub metadata: Option<serde_json::Value>,
    pub user_id: Option<String>,
    pub org_id: Option<String>,
}
```

This change makes expires_at_seconds optional.