### PR TITLE
Add new fields to FetchOrgResponse model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propelauth"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["support@propelauth.com"]
 description = "A Rust crate for managing authentication and authorization with support for multi-tenant / B2B products, powered by PropelAuth"
 keywords = ["authentication", "auth", "authorization", "b2b", "tenant"]

--- a/src/models/fetch_org_response.rs
+++ b/src/models/fetch_org_response.rs
@@ -37,6 +37,15 @@ pub struct FetchOrgResponse {
     pub custom_role_mapping_name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub legacy_org_id: Option<String>,
+    pub url_safe_org_slug: String,
+    pub can_setup_saml: bool,
+    pub is_saml_in_test_mode: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    pub domain_autojoin: bool,
+    pub domain_restrict: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_org_id: Option<string>
 }
 
 impl FetchOrgResponse {
@@ -45,6 +54,11 @@ impl FetchOrgResponse {
         name: String,
         metadata: OrgMetadata,
         is_saml_configured: bool,
+        url_safe_org_slug: String,
+        can_setup_saml: bool,
+        is_saml_in_test_mode: bool,
+        domain_autojoin: bool,
+        domain_restrict: bool,
     ) -> FetchOrgResponse {
         FetchOrgResponse {
             org_id,
@@ -54,6 +68,14 @@ impl FetchOrgResponse {
             max_users: None,
             custom_role_mapping_name: None,
             legacy_org_id: None,
+            url_safe_org_slug,
+            can_setup_saml,
+            is_saml_in_test_mode,
+            domain: None,
+            domain_autojoin,
+            domain_restrict,
         }
     }
 }
+
+

--- a/src/models/fetch_org_response.rs
+++ b/src/models/fetch_org_response.rs
@@ -78,7 +78,7 @@ impl FetchOrgResponse {
 
 // A Simple org response is used for fetching multiple orgs until that API returns a full org object
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct FetchSimpleOrgResponse {
+pub struct FetchOrgBasicResponse {
     pub org_id: String,
     pub name: String,
     pub is_saml_configured: bool,
@@ -92,14 +92,14 @@ pub struct FetchSimpleOrgResponse {
     pub legacy_org_id: Option<String>,
 }
 
-impl crate::models::FetchSimpleOrgResponse {
+impl crate::models::FetchOrgBasicResponse {
     pub fn new(
         org_id: String,
         name: String,
         metadata: OrgMetadata,
         is_saml_configured: bool,
-    ) -> crate::models::FetchSimpleOrgResponse {
-        crate::models::FetchSimpleOrgResponse {
+    ) -> crate::models::FetchOrgBasicResponse {
+        crate::models::FetchOrgBasicResponse {
             org_id,
             name,
             metadata,

--- a/src/models/fetch_org_response.rs
+++ b/src/models/fetch_org_response.rs
@@ -76,4 +76,40 @@ impl FetchOrgResponse {
     }
 }
 
+// A Simple org response is used for fetching multiple orgs until that API returns a full org object
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+pub struct FetchSimpleOrgResponse {
+    pub org_id: String,
+    pub name: String,
+    pub is_saml_configured: bool,
+    #[serde(default, skip_serializing_if = "OrgMetadata::is_empty")]
+    pub metadata: OrgMetadata,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_users: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_role_mapping_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub legacy_org_id: Option<String>,
+}
+
+impl crate::models::FetchSimpleOrgResponse {
+    pub fn new(
+        org_id: String,
+        name: String,
+        metadata: OrgMetadata,
+        is_saml_configured: bool,
+    ) -> crate::models::FetchSimpleOrgResponse {
+        crate::models::FetchSimpleOrgResponse {
+            org_id,
+            name,
+            metadata,
+            is_saml_configured,
+            max_users: None,
+            custom_role_mapping_name: None,
+            legacy_org_id: None,
+        }
+    }
+}
+
+
 

--- a/src/models/fetch_org_response.rs
+++ b/src/models/fetch_org_response.rs
@@ -44,8 +44,6 @@ pub struct FetchOrgResponse {
     pub domain: Option<String>,
     pub domain_autojoin: bool,
     pub domain_restrict: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub legacy_org_id: Option<string>
 }
 
 impl FetchOrgResponse {

--- a/src/models/fetch_org_response.rs
+++ b/src/models/fetch_org_response.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrgMetadata {
     #[serde(flatten)]
-    metadata: HashMap<String, Value>,
+    pub metadata: HashMap<String, Value>,
 }
 
 impl OrgMetadata {

--- a/src/models/fetch_orgs_response.rs
+++ b/src/models/fetch_orgs_response.rs
@@ -14,7 +14,7 @@
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct FetchOrgsResponse {
     #[serde(rename = "orgs")]
-    pub orgs: Vec<crate::models::FetchOrgResponse>,
+    pub orgs: Vec<crate::models::FetchSimpleOrgResponse>,
     #[serde(rename = "total_orgs")]
     pub total_orgs: i64,
     #[serde(rename = "current_page")]
@@ -26,7 +26,7 @@ pub struct FetchOrgsResponse {
 }
 
 impl FetchOrgsResponse {
-    pub fn new(orgs: Vec<crate::models::FetchOrgResponse>, total_orgs: i64, current_page: i64, page_size: i64, has_more_results: bool) -> FetchOrgsResponse {
+    pub fn new(orgs: Vec<crate::models::FetchSimpleOrgResponse>, total_orgs: i64, current_page: i64, page_size: i64, has_more_results: bool) -> FetchOrgsResponse {
         FetchOrgsResponse {
             orgs,
             total_orgs,

--- a/src/models/fetch_orgs_response.rs
+++ b/src/models/fetch_orgs_response.rs
@@ -14,7 +14,7 @@
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct FetchOrgsResponse {
     #[serde(rename = "orgs")]
-    pub orgs: Vec<crate::models::FetchSimpleOrgResponse>,
+    pub orgs: Vec<crate::models::FetchOrgBasicResponse>,
     #[serde(rename = "total_orgs")]
     pub total_orgs: i64,
     #[serde(rename = "current_page")]
@@ -26,7 +26,7 @@ pub struct FetchOrgsResponse {
 }
 
 impl FetchOrgsResponse {
-    pub fn new(orgs: Vec<crate::models::FetchSimpleOrgResponse>, total_orgs: i64, current_page: i64, page_size: i64, has_more_results: bool) -> FetchOrgsResponse {
+    pub fn new(orgs: Vec<crate::models::FetchOrgBasicResponse>, total_orgs: i64, current_page: i64, page_size: i64, has_more_results: bool) -> FetchOrgsResponse {
         FetchOrgsResponse {
             orgs,
             total_orgs,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -57,6 +57,7 @@ pub mod fetch_org_order_by;
 pub use self::fetch_org_order_by::FetchOrgOrderBy;
 pub mod fetch_org_response;
 pub use self::fetch_org_response::FetchOrgResponse;
+pub use self::fetch_org_response::FetchSimpleOrgResponse;
 pub mod fetch_orgs_response;
 pub use self::fetch_orgs_response::FetchOrgsResponse;
 pub mod fetch_users_order_by;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -57,7 +57,7 @@ pub mod fetch_org_order_by;
 pub use self::fetch_org_order_by::FetchOrgOrderBy;
 pub mod fetch_org_response;
 pub use self::fetch_org_response::FetchOrgResponse;
-pub use self::fetch_org_response::FetchSimpleOrgResponse;
+pub use self::fetch_org_response::FetchOrgBasicResponse;
 pub mod fetch_orgs_response;
 pub use self::fetch_orgs_response::FetchOrgsResponse;
 pub mod fetch_users_order_by;


### PR DESCRIPTION
The FetchOrgResponse model has been expanded with new fields related to organization's SAML settings and domain restrictions. These include url_safe_org_slug, can_setup_saml, is_saml_in_test_mode, domain, domain_autojoin, and domain_restrict. This update improves the granularity and completeness of the data returned by organization fetch requests to include all of the fields that are actually returned from the API.