### PR TITLE
chore: Add the repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A Rust crate for managing authentication and authorization with s
 keywords = ["authentication", "auth", "authorization", "b2b", "tenant"]
 categories = ["authentication"]
 homepage = "https://www.propelauth.com"
+repository = "https://github.com/PropelAuth/rust/"
 license = "MIT"
 edition = "2018"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.