### PR TITLE
Add support for Axum 8, Bump version to 0.21.0 and update dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ edition = "2018"
 actix-web = { version = "4", optional = true }
 axum_06 = { package = "axum", version = "^0.6", optional = true }
 axum_07 = { package = "axum", version = "^0.7", optional = true }
-chrono = "0.4.23"
-jsonwebtoken = "8.1.1"
+axum_08 = { package = "axum", version = "^0.8", optional = true }
+chrono = "0.4.39"
+jsonwebtoken = "^9.3.0"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
-thiserror = "^1.0"
-tower = { version = "^0.4", optional = true }
+thiserror = "^2.0"
+tower = { version = "^0.5", optional = true }
 url = "^2.2"
 uuid = { version = "^1.0", features = ["serde"] }
 hex = "0.4.3"
@@ -30,13 +31,14 @@ version = "^0.12"
 default-features = false
 
 [dev-dependencies]
-openssl = "0.10.43"
+openssl = "0.10.68"
 
 [features]
 default = ["reqwest/default", "__reqwest"]
 rustls = ["__reqwest", "reqwest/rustls-tls", "reqwest/http2", "reqwest/charset"]
 axum06 = ["dep:axum_06", "dep:tower"]
 axum07 = ["dep:axum_07", "dep:tower"]
+axum08 = ["dep:axum_08", "dep:tower"]
 actix4 = ["dep:actix-web"]
 __reqwest = ["reqwest/json", "reqwest/multipart"]
 

--- a/src/axum08/mod.rs
+++ b/src/axum08/mod.rs
@@ -1,0 +1,116 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum_08::extract::FromRequestParts;
+use axum_08::http::header::AUTHORIZATION;
+use axum_08::http::request::Parts;
+use axum_08::http::StatusCode;
+use axum_08::response::IntoResponse;
+use axum_08::{body::Body, http::Request, response::Response};
+use tower::{Layer, Service};
+
+use crate::propelauth::auth::PropelAuth;
+use crate::propelauth::errors::{UnauthorizedError, UnauthorizedOrForbiddenError};
+use crate::propelauth::token_models::User;
+
+impl<S> FromRequestParts<S> for User
+where
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Self, Self::Rejection> {
+        let auth_header = parts
+            .headers
+            .get(AUTHORIZATION)
+            .and_then(|header| header.to_str().ok())
+            .ok_or((StatusCode::UNAUTHORIZED, "Unauthorized"))?;
+
+        let auth = parts
+            .extensions
+            .get::<Arc<PropelAuth>>()
+            .ok_or((StatusCode::INTERNAL_SERVER_ERROR, "No layer found"))?;
+
+        match auth.verify().validate_authorization_header(auth_header) {
+            Ok(user) => Ok(user),
+            Err(UnauthorizedError::Unauthorized(_)) => {
+                Err((StatusCode::UNAUTHORIZED, "Unauthorized"))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PropelAuthLayer {
+    auth: Arc<PropelAuth>,
+}
+
+impl PropelAuthLayer {
+    pub fn new(auth: PropelAuth) -> PropelAuthLayer {
+        PropelAuthLayer {
+            auth: Arc::new(auth),
+        }
+    }
+}
+
+impl<S> Layer<S> for PropelAuthLayer {
+    type Service = PropelAuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PropelAuthMiddleware {
+            inner,
+            auth: self.auth.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PropelAuthMiddleware<S> {
+    inner: S,
+    auth: Arc<PropelAuth>,
+}
+
+impl<S> Service<Request<Body>> for PropelAuthMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: Request<Body>) -> Self::Future {
+        request.extensions_mut().insert(self.auth.clone());
+        let future = self.inner.call(request);
+        Box::pin(async move {
+            let response: Response = future.await?;
+            Ok(response)
+        })
+    }
+}
+
+impl IntoResponse for UnauthorizedError {
+    fn into_response(self) -> Response {
+        (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+    }
+}
+
+impl IntoResponse for UnauthorizedOrForbiddenError {
+    fn into_response(self) -> Response {
+        match self {
+            UnauthorizedOrForbiddenError::Unauthorized(_) => {
+                (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+            }
+            UnauthorizedOrForbiddenError::Forbidden(_) => {
+                (StatusCode::FORBIDDEN, "Forbidden").into_response()
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! ## Axum
 //!
-//! To use Axum, make sure to enable the `axum_07` (or `axum_06`) feature in your Cargo.toml.
+//! To use Axum, make sure to enable the `axum_08` (or `axum_07` or `axum_06`) feature in your Cargo.toml.
 //!
 //! Then, add PropelAuthLayer to your Router:
 //!
@@ -177,6 +177,9 @@ pub mod axum06;
 
 #[cfg(feature = "axum07")]
 pub mod axum07;
+
+#[cfg(feature = "axum08")]
+pub mod axum08;
 
 #[cfg(feature = "actix4")]
 pub mod actix;


### PR DESCRIPTION
Updated key dependencies like `chrono`, `jsonwebtoken`, `openssl`, and `tower` to their latest versions. Introduced support for `axum` v0.8 and adjusted related features. These changes enhance compatibility, functionality, and maintainability of the crate.