### PR TITLE
update jsonwebtoken dep and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "propelauth"
-version = "0.22.2"
+version = "0.23.0"
 authors = ["support@propelauth.com"]
 description = "A Rust crate for managing authentication and authorization with support for multi-tenant / B2B products, powered by PropelAuth"
 keywords = ["authentication", "auth", "authorization", "b2b", "tenant"]


### PR DESCRIPTION
## Tests
Smoke tested w/ a local example app against a test project in prod. Basic user authentication on the route (which is all that uses jsonwebtoken) and a BE API fetch.